### PR TITLE
Fix painting bug in Tab/TabPane and implement demo

### DIFF
--- a/example/lib/src/navigation.dart
+++ b/example/lib/src/navigation.dart
@@ -30,8 +30,8 @@ class NavigationDemo extends StatelessWidget {
         return Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: const [
-            // TabsDemo(),
-            // SizedBox(width: 12),
+            TabsDemo(),
+            SizedBox(width: 12),
             // ExpandersDemo(),
             // SizedBox(width: 12),
             // AccordionDemo(),
@@ -40,6 +40,85 @@ class NavigationDemo extends StatelessWidget {
           ],
         );
       },
+    );
+  }
+}
+
+class TabsDemo extends StatefulWidget {
+  const TabsDemo({Key? key}) : super(key: key);
+
+  @override
+  _TabsDemoState createState() => _TabsDemoState();
+}
+
+class _TabsDemoState extends State<TabsDemo> {
+  @override
+  Widget build(BuildContext context) {
+    return BorderPane(
+      borderColor: Color(0xff999999),
+      backgroundColor: const Color(0xffffffff),
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(4, 2, 4, 4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            BoldText('Tab Pane'),
+            SizedBox(height: 4),
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: 400,
+                maxHeight: 100,
+              ),
+              child: TabPane(
+                tabs: [
+                  Tab(
+                    label: 'Pomegranate',
+                    builder: (BuildContext context) {
+                      return Center(
+                          child: ColoredText('Red', Color(0xffff0000)));
+                    },
+                  ),
+                  Tab(
+                    label: 'Mango',
+                    builder: (BuildContext context) {
+                      return Center(
+                          child: ColoredText('Orange', Color(0xffffa500)));
+                    },
+                  ),
+                  Tab(
+                    label: 'Banana',
+                    builder: (BuildContext context) {
+                      return Center(
+                          child: ColoredText('Yellow', Color(0xffffff00)));
+                    },
+                  ),
+                  Tab(
+                    label: 'Lime',
+                    builder: (BuildContext context) {
+                      return Center(
+                          child: ColoredText('Green', Color(0xff00ff00)));
+                    },
+                  ),
+                  Tab(
+                    label: 'Blueberry',
+                    builder: (BuildContext context) {
+                      return Center(
+                          child: ColoredText('Blue', Color(0xff0000ff)));
+                    },
+                  ),
+                  Tab(
+                    label: 'Plum',
+                    builder: (BuildContext context) {
+                      return Center(
+                          child: ColoredText('Purple', Color(0xff800080)));
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/example/lib/src/navigation.dart
+++ b/example/lib/src/navigation.dart
@@ -44,14 +44,9 @@ class NavigationDemo extends StatelessWidget {
   }
 }
 
-class TabsDemo extends StatefulWidget {
+class TabsDemo extends StatelessWidget {
   const TabsDemo({Key? key}) : super(key: key);
 
-  @override
-  _TabsDemoState createState() => _TabsDemoState();
-}
-
-class _TabsDemoState extends State<TabsDemo> {
   @override
   Widget build(BuildContext context) {
     return BorderPane(

--- a/lib/src/tab_pane.dart
+++ b/lib/src/tab_pane.dart
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 class Tab {

--- a/lib/src/tab_pane.dart
+++ b/lib/src/tab_pane.dart
@@ -32,7 +32,7 @@ class TabPane extends StatefulWidget {
     Key? key,
     this.initialSelectedIndex = 0,
     required this.tabs,
-  })  : super(key: key);
+  }) : super(key: key);
 
   final int initialSelectedIndex;
   final List<Tab> tabs;
@@ -57,7 +57,7 @@ class _TabPaneState extends State<TabPane> {
       final Tab tab = widget.tabs[i];
       if (i == selectedIndex) {
         tabs.add(
-          Ink(
+          DecoratedBox(
             decoration: const BoxDecoration(
               color: Color(0xfff7f5ee),
               border: Border(
@@ -88,7 +88,7 @@ class _TabPaneState extends State<TabPane> {
                   selectedIndex = i;
                 });
               },
-              child: Ink(
+              child: DecoratedBox(
                 decoration: const BoxDecoration(
                   color: Color(0xffc4c3bc),
                   border: Border(
@@ -113,7 +113,7 @@ class _TabPaneState extends State<TabPane> {
         );
       }
       tabs.add(
-        Ink(
+        DecoratedBox(
           decoration: const BoxDecoration(
             border: Border(
               bottom: BorderSide(width: 1, color: Color(0xff999999)),
@@ -125,7 +125,7 @@ class _TabPaneState extends State<TabPane> {
     }
     tabs.add(
       Expanded(
-        child: Ink(
+        child: DecoratedBox(
           decoration: const BoxDecoration(
             border: Border(
               bottom: BorderSide(width: 1, color: Color(0xff999999)),
@@ -144,7 +144,7 @@ class _TabPaneState extends State<TabPane> {
           children: tabs,
         ),
         Expanded(
-          child: Ink(
+          child: DecoratedBox(
             decoration: const BoxDecoration(
               border: Border(
                 left: BorderSide(width: 1, color: Color(0xff999999)),


### PR DESCRIPTION
I hope my layout is fine in the example - I've still got to work on figuring that out for myself.

I also noticed that Ink widgets were present in the implementation of Tab/TabPane without any Material to paint on, so I replaced those with DecoratedBox widgets. There are certainly other solutions to achieve the same effect but this is the most lightweight one that I've found.